### PR TITLE
Fix: textarea macOS 폰트 대응 이슈

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -387,7 +387,7 @@ const App: React.FC = () => {
                   className="w-full h-full resize-none outline-none p-2"
                   spellCheck="false"
                   placeholder="몰랭 코드 입력..."
-                  style={{ fontFamily: "Consolas, Gulim" }}
+                  style={{ fontFamily: "Menlo, Monaco, Consolas, Gulim" }}
                 />
                 <div className="flex flex-col">
                   <button


### PR DESCRIPTION
macOS 에서 `Consolas`, `Gulim` 이 없어 바탕체로 깨지는 문제가 발생하여 
- `Menlo`
- `Monaco`

위 두 폰트를 `textarea`의 `font-family` 옵션에 추가하여 해결했습니다.